### PR TITLE
Handle cancelled target URL prompt in DOCX generator

### DIFF
--- a/snortgen/docx_report_generator.py
+++ b/snortgen/docx_report_generator.py
@@ -19,6 +19,10 @@ def generate_docx_report(vulnerabilities, template_path, output_path):
 
     # Ask for target URL
     target_url = questionary.text("🌐 Enter the target URL:", style=custom_style).ask()
+    if target_url is None:
+        print("\n🛑 Cancelled.")
+        return
+    target_url = (target_url or "").strip()
 
     # Replace placeholders
     for paragraph in doc.paragraphs:


### PR DESCRIPTION
## Summary
- handle cancellation when prompting for a target URL when generating a DOCX report
- sanitize the collected target URL before filling placeholders so replacements always use a string

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d671ddc7508327ab87e2ca52ea1376